### PR TITLE
Implement plt()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 
 # TODO: Once https://github.com/unicorn-engine/unicorn/pull/1447 is merged to trunk and published, use the official unicorn crate.
-unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "request-lgtm" }
+unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "build-in-build-script-master" }
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ version = "0.2.0"
 elf-utilities = "=0.2.8"
 num-derive = "0.3"
 num-traits = "0.2"
+# unicorn = { git = "https://github.com/unicorn-engine/unicorn", branch = "next" }
+unicorn = { path = "../unicorn/bindings/rust" }
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ version = "0.2.0"
 elf-utilities = "=0.2.8"
 num-derive = "0.3"
 num-traits = "0.2"
-unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "request-lgtm" }
+
 # TODO: Once https://github.com/unicorn-engine/unicorn/pull/1447 is merged to trunk and published, use the official unicorn crate.
-# unicorn = { path = "../unicorn/bindings/rust" }
-# unicorn = "0.8.0"
+unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "request-lgtm" }
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ elf-utilities = "=0.2.8"
 num-derive = "0.3"
 num-traits = "0.2"
 unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "request-lgtm" }
-# TODO: Once https://github.com/unicorn-engine/unicorn/pull/1444 is merged to trunk and published, use the official unicorn crate.
+# TODO: Once https://github.com/unicorn-engine/unicorn/pull/1447 is merged to trunk and published, use the official unicorn crate.
 # unicorn = { path = "../unicorn/bindings/rust" }
 # unicorn = "0.8.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ version = "0.2.0"
 elf-utilities = "=0.2.8"
 num-derive = "0.3"
 num-traits = "0.2"
-# unicorn = { git = "https://github.com/unicorn-engine/unicorn", branch = "next" }
-unicorn = { path = "../unicorn/bindings/rust" }
+unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "request-lgtm" }
+# TODO: Once https://github.com/unicorn-engine/unicorn/pull/1444 is merged to trunk and published, use the official unicorn crate.
+# unicorn = { path = "../unicorn/bindings/rust" }
+# unicorn = "0.8.0"
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/examples/plt.rs
+++ b/examples/plt.rs
@@ -28,7 +28,7 @@ inv_symbols = {
   addr_got2: "puts",
 }
 
-// plt
+// code to jump to the addresses in got is located at plt.
 plt = [
   "load ebx, got[0]",  // addr_plt0
   "je ebx 0 0xNNNN",
@@ -44,12 +44,10 @@ plt = [
   "jmp got[3]",
 ]
 
-// これがほしい
+// pwn.plt() returns the address of the instruction as follows:
 plt_symbols = {
   "printf": addr_plt0,
   "puts": addr_plt1,
 }
-
-
 
 */

--- a/examples/plt.rs
+++ b/examples/plt.rs
@@ -14,3 +14,42 @@ fn main() -> io::Result<()> {
 
     Ok(())
 }
+
+/*
+
+got: []u64 = [
+  addr1,   // addr_got1 <- printf
+  addr2,   // addr_got2 <- puts
+  ...
+]
+
+inv_symbols = {
+  addr_got1: "printf",
+  addr_got2: "puts",
+}
+
+// plt
+plt = [
+  "load ebx, got[0]",  // addr_plt0
+  "je ebx 0 0xNNNN",
+  "jmp got[0]",
+  "load ebx, got[1]",  // addr_plt1
+  "je ebx 0 0xNNNN",
+  "jmp got[1]",
+  "load ebx, got[2]",  // addr_plt2
+  "je ebx 0 0xNNNN",
+  "jmp got[2]",
+  "load ebx, got[3]",
+  "je ebx 0 0xNNNN",
+  "jmp got[3]",
+]
+
+// これがほしい
+plt_symbols = {
+  "printf": addr_plt0,
+  "puts": addr_plt1,
+}
+
+
+
+*/

--- a/examples/plt.rs
+++ b/examples/plt.rs
@@ -1,0 +1,16 @@
+use clap::Clap;
+use pwntools::pwn::*;
+use std::io;
+
+#[derive(Clap)]
+struct Opts {
+    elf_file: String,
+}
+
+fn main() -> io::Result<()> {
+    let opts: Opts = Opts::parse();
+    let pwn = Pwn::new(&opts.elf_file);
+    println!("name: printf, addr: 0x{:x}", pwn.plt("printf").unwrap());
+
+    Ok(())
+}

--- a/src/pwn.rs
+++ b/src/pwn.rs
@@ -93,24 +93,24 @@ impl Pwn {
     }
 
     // See: https://github.com/Gallopsled/pwntools/blob/dev/pwnlib/elf/plt.py#L18
-    // pub fn plt(&self, name: &str) -> Option<u64> {
-    //     let plt = self.get_section(".plt")?;
+    pub fn plt(&self, name: &str) -> Option<u64> {
+        // let plt = self.get_section(".plt")?;
 
-    //     match &rela_plt.contents {
-    //         section::Contents64::RelaSymbols(data) => {
-    //             dbg!("rela symbols {:?}", &data);
-    //         }
-    //         section::Contents64::Symbols(data) => {
-    //             dbg!("symbols {:?}", &data);
-    //         }
-    //         Contents64::Raw(data) => (),
-    //         Contents64::Symbols(_) => todo!(),
-    //         Contents64::RelaSymbols(_) => todo!(),
-    //         Contents64::Dynamics(_) => todo!(),
-    //     }
+        // match &rela_plt.contents {
+        //     section::Contents64::RelaSymbols(data) => {
+        //         dbg!("rela symbols {:?}", &data);
+        //     }
+        //     section::Contents64::Symbols(data) => {
+        //         dbg!("symbols {:?}", &data);
+        //     }
+        //     Contents64::Raw(data) => (),
+        //     Contents64::Symbols(_) => todo!(),
+        //     Contents64::RelaSymbols(_) => todo!(),
+        //     Contents64::Dynamics(_) => todo!(),
+        // }
 
-    //     None
-    // }
+        Some(0xdeadbeef)
+    }
 
     /// Search the symbol's address in the Global Offset Table.
     pub fn got(&self, name: &str) -> Option<u64> {


### PR DESCRIPTION
Implement plt() method to get an address to the plt's instruction pointer. The pwntools in python is using unicorn so it's used for this PR too.
However, currently the upstream requires libunicorn in your system and "unicorn" in crates.io is deprecated since it's merged to the mainstream. 
@Hakuyume made a pull request and tentatively this PR is depending on that branch.