### PR TITLE
Use official unicorn-engine 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ num-derive = "0.3"
 num-traits = "0.2"
 
 # TODO: Once https://github.com/unicorn-engine/unicorn/pull/1447 is merged to trunk and published, use the official unicorn crate.
-unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "build-in-build-script-master" }
+# unicorn = { git = "https://github.com/Hakuyume/unicorn", branch = "build-in-build-script-master" }
+unicorn-engine = "2.0.0-rc3"
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/src/pwn.rs
+++ b/src/pwn.rs
@@ -16,7 +16,7 @@ use elf_utilities::{
     file, section,
     section::{Contents64, Section64},
 };
-use unicorn::unicorn_const::{Arch, HookType, Mode, Permission};
+use unicorn_engine::unicorn_const::{Arch, HookType, Mode, Permission};
 
 // use num_derive::{FromPrimitive, ToPrimitive};
 // use num_traits::FromPrimitive;
@@ -107,7 +107,7 @@ impl Pwn {
         };
 
         let mut unicorn =
-            unicorn::Unicorn::new(Arch::X86, Mode::LITTLE_ENDIAN | Mode::MODE_64).unwrap();
+            unicorn_engine::Unicorn::new(Arch::X86, Mode::LITTLE_ENDIAN | Mode::MODE_64).unwrap();
         let mut emu = unicorn.borrow();
 
         let address = plt.header.sh_addr;


### PR DESCRIPTION
Dependency of git prevents from publishing the package to crate.io.
This PR uses the official unicorn-engine instead of forked version.

There's an issue that the official unicorn-engine builds the native library every time probably because its build script downloads the git repository and it accidentally changes the last modified time, but this PR doesn't care about that.
If you'd like to avoid the problem, please use the dependency commented out.