### PR TITLE
Use clap 3.0.0-beta.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ num-traits = "0.2"
 unicorn-engine = "2.0.0-rc3"
 
 [dev-dependencies]
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"

--- a/examples/plt.rs
+++ b/examples/plt.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 use pwntools::pwn::*;
 use std::io;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     elf_file: String,
 }

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 use pwntools::{connection::Connection, connection::Process};
 use std::io;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     program: String,
 }

--- a/examples/pwn.rs
+++ b/examples/pwn.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 use pwntools::pwn::*;
 use std::io;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     elf_file: String,
 }

--- a/examples/solve_beginners_pwn.rs
+++ b/examples/solve_beginners_pwn.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 use pwntools::{connection::Connection, connection::Process, pwn::*, util::*};
 use std::{io, time};
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     elf_file: String,
 }


### PR DESCRIPTION
clap dependency has been broken before clap 3.0.0-beta.4 due to version pinning problem. This PR upgrades the clap to the latest version.